### PR TITLE
How to use theine when not using Gemfile

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,14 @@ theine_set_ruby after upgrading.
 
 Start up the theine server in the root of your Rails project:
 
+If using bundler:
+
   bundle exec theine_server
+  
+As a RubyGems:
+
+  theine_server
+
 
 Then run any rails command using theine (don't use bundle exec):
 


### PR DESCRIPTION
The README given just instruction how to use theine when gem is in Bundler (but installation suggest using RubyGems). 
'bundle exec theine_server' will end up with:
'Gem::LoadError: theine is not part of the bundle. Add it to Gemfile.'
