### PR TITLE
Explicitly require rake when running the rake command

### DIFF
--- a/lib/theine/worker.rb
+++ b/lib/theine/worker.rb
@@ -11,6 +11,7 @@ module Theine
         require 'rails/commands'
       },
       rake: proc {
+        require 'rake'
         ::Rails.application.load_tasks if defined? ::Rails
 
         ARGV.each do |task|


### PR DESCRIPTION
- fixes Rake tasks for Rails 3
- fixes #8
