### PR TITLE
Added the --debug option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,11 @@ Start up the theine server in the root of your Rails project:
 
   theine_server
 
+You can also add `--debug` mode so that the spawned workers will be running
+in debug mode:
+
+  theine_server --debug
+
 Then run any rails command using theine (don't use bundle exec):
 
   # Rails commands

--- a/lib/theine/server.rb
+++ b/lib/theine/server.rb
@@ -26,10 +26,10 @@ module Theine
     def add_worker
       path = File.expand_path('../worker.rb', __FILE__)
       port = @workers_mutex.synchronize { @available_ports.shift }
-      puts "(spawn #{port})"
+      puts "(spawn #{"#{port} #{debug}".strip})"
       spawn("screen", "-d", "-m", "-S", worker_session_name(port),
         "sh", "-c",
-        "ruby #{path} #{config.base_port.to_s} #{port.to_s} #{config.rails_root}")
+        "jruby #{debug} #{path} #{config.base_port.to_s} #{port.to_s} #{config.rails_root}")
       @workers_mutex.synchronize { @spawning_workers << port }
     end
 
@@ -126,6 +126,10 @@ module Theine
       DRb.start_service("druby://localhost:#{config.base_port}", self)
       check_min_free_workers
       DRb.thread.join
+    end
+
+    def debug
+      "--debug" if ARGV.any? {|a| a.to_s.strip == "--debug" }
     end
   end
 end


### PR DESCRIPTION
When I'm debugging within my specs, I typically use the `debugger` to walk through my code. By adding the `--debug` option, it allows the [debugger to correctly handle next](https://github.com/jruby/jruby/wiki/UsingTheJRubyDebugger) in the spawned workers.
