### PR TITLE
Load rails server from local scripts directory, if possible

### DIFF
--- a/lib/theine/worker.rb
+++ b/lib/theine/worker.rb
@@ -8,7 +8,12 @@ module Theine
 
     COMMANDS = {
       rails: proc {
-        require 'rails/commands'
+        local_path = File.join(Rails.root, "script/rails")
+        if File.exists?(local_path)
+          load 'script/rails'
+        else
+          require 'rails/commands'
+        end
       },
       rake: proc {
         require 'rake'

--- a/theine.gemspec
+++ b/theine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'theine'
-  s.version     = '0.0.14'
+  s.version     = '0.0.15'
   s.summary     = "Theine"
   s.description = "A Rails preloader for JRuby"
   s.authors     = ["Jan Berdajs"]


### PR DESCRIPTION
Sometimes, customizations are put into `script/rails`. This change allows theine to prefer to start rails from there instead of the rails gem.