### PR TITLE
Accept rake env variables as command parameters

### DIFF
--- a/lib/theine/worker.rb
+++ b/lib/theine/worker.rb
@@ -14,7 +14,16 @@ module Theine
         require 'rake'
         ::Rails.application.load_tasks if defined? ::Rails
 
-        ARGV.each do |task|
+        tasks = []
+        ARGV.each do |arg|
+          if arg =~ /^(\w+)=(.*)$/m
+            ENV[$1] = $2
+          else
+            tasks << arg
+          end
+        end
+
+        tasks.each do |task|
           is_test_task = task =~ /^(spec|test)$/
           if is_test_task
             previous_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"


### PR DESCRIPTION
Fixes #13 

Useful for running single tests:
`rake test TEST=test/models/user_test.rb`
